### PR TITLE
Visual Studio compatibility fixes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,11 +21,14 @@ if(LIBZIP_INCLUDE_DIRS)
 include_directories ("${LIBZIP_INCLUDE_DIRS}")
 endif(LIBZIP_INCLUDE_DIRS)
 
-add_custom_command(OUTPUT ov3.fwpkg.o
-	WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
-	COMMAND ld -r -b binary -o ${CMAKE_CURRENT_BINARY_DIR}/ov3.fwpkg.o ov3.fwpkg
-	COMMAND objcopy --rename-section .data=.rodata,contents,readonly ${CMAKE_CURRENT_BINARY_DIR}/ov3.fwpkg.o ${CMAKE_CURRENT_BINARY_DIR}/ov3.fwpkg.o
-	MAIN_DEPENDENCY ov3.fwpkg)
+function(convert_to_resource input)
+	string(REGEX REPLACE "\\.| |-" "_" identifier _binary_${input})
+	file(READ ${input} filedata HEX)
+	string(REGEX REPLACE "([0-9a-f][0-9a-f])" "0x\\1," filedata ${filedata})
+	file(WRITE src/${identifier}.c "const unsigned char ${identifier}[] = {${filedata}};\nconst unsigned ${identifier}_size = sizeof(${identifier});\n")
+	file(WRITE include/${identifier}.h "extern const unsigned char ${identifier}[];\nextern const unsigned ${identifier}_size;\n")
+endfunction()
+convert_to_resource("ov3.fwpkg")
 
 find_program(GPERF NAMES gperf)
 if(NOT GPERF)
@@ -39,7 +42,6 @@ add_custom_command(OUTPUT reg_gperf.h
 
 file(GLOB_RECURSE SOURCES src/*.c)
 list(APPEND SOURCES
-	${CMAKE_CURRENT_BINARY_DIR}/ov3.fwpkg.o
 	${CMAKE_CURRENT_BINARY_DIR}/reg_gperf.h)
 list(APPEND LIBRARIES
 	${LIBFTDI_LDFLAGS}

--- a/include/bit.h
+++ b/include/bit.h
@@ -7,9 +7,10 @@
 #include <chb.h>
 
 #include <memory.h>
+#include <stdint.h>
 
 struct bit {
-	const void* data;
+	const uint8_t* data;
 	size_t size;
 
 	const char* ncd_filename;

--- a/include/ov.h
+++ b/include/ov.h
@@ -22,13 +22,26 @@ extern "C" {
 
 struct ov_device;
 
-struct __attribute__((packed)) ov_packet {
+#ifdef _MSC_VER
+#pragma pack(push, 1)
+#endif
+struct
+#ifdef __GNUC__
+	__attribute__((packed))
+#elif !defined(_MSC_VER)
+	#error Please provide __attribute__((packed)) for your compiler
+#endif
+ov_packet {
 	uint8_t  magic;
 	uint16_t flags;
 	uint16_t size;
 	uint32_t timestamp : 24;
 	uint8_t  data[];
 };
+#ifdef _MSC_VER
+#pragma pack(pop)
+#endif
+
 
 typedef void (*ov_packet_decoder_callback)(struct ov_packet*, void*);
 

--- a/src/bit.c
+++ b/src/bit.c
@@ -5,9 +5,17 @@
 #include <stdint.h>
 #include <string.h>
 
-#include <arpa/inet.h>
-
 #define PORTB_DONE_BIT (1 << 2)
+
+inline static uint16_t uint16_from_big_endian(const uint8_t* data)
+{
+	return (data[0] << 8) | data[1];
+}
+
+inline static uint32_t uint32_from_big_endian(const uint8_t* data)
+{
+	return (data[0] << 24) | (data[1] << 16) | (data[2] << 8) | data[3];
+}
 
 inline static uint8_t bitreverse8(uint8_t x) {
 	static const uint8_t map[256] = {
@@ -53,8 +61,7 @@ static int bit_do_parse_field_str(struct bit* bit, uint8_t key, const char** str
 	bit->data += sizeof(key);
 	bit->size -= sizeof(key);
 
-	memcpy(&len, bit->data, sizeof(len));
-	len = htons(len);
+	len = uint16_from_big_endian(bit->data);
 
 	bit->data += sizeof(len);
 	bit->size -= sizeof(len);
@@ -105,8 +112,7 @@ static int bit_do_parse_field7(struct bit* bit) {
 	bit->data += sizeof(key);
 	bit->size -= sizeof(key);
 
-	memcpy(&len, bit->data, sizeof(len));
-	len = htonl(len);
+	len = uint32_from_big_endian(bit->data);
 
 	bit->bit_length = len;
 	bit->data += sizeof(len);

--- a/src/fwpkg.c
+++ b/src/fwpkg.c
@@ -1,12 +1,10 @@
 /* SPDX-License-Identifier: LGPL-3.0-or-later */
 
 #include <fwpkg.h>
+#include <_binary_ov3_fwpkg.h>
 
 #include <stdlib.h>
 #include <string.h>
-
-extern const char _binary_ov3_fwpkg_start[];
-extern const char _binary_ov3_fwpkg_end[];
 
 static int fwpkg_read_file(struct fwpkg* fwpkg, void* buf, size_t* size, zip_uint64_t index) {
 	struct zip_file* file = zip_fopen_index(fwpkg->pkg, index, 0);
@@ -98,8 +96,8 @@ int fwpkg_init_from_preload(struct fwpkg* fwpkg) {
 
 	memset(fwpkg, 0, sizeof(struct fwpkg));
 
-	src = zip_source_buffer_create((const void*)_binary_ov3_fwpkg_start,
-		(const void*)_binary_ov3_fwpkg_end - (const void*)_binary_ov3_fwpkg_start, 0, &error);
+	src = zip_source_buffer_create(_binary_ov3_fwpkg,
+		_binary_ov3_fwpkg_size, 0, &error);
 	if (!src) {
 		fwpkg->error_str = zip_error_strerror(&error);
 		return -1;


### PR DESCRIPTION
The generated C source file is portable. This is preliminary change to
compile libopenvizsla with Visual Studio.