### PR TITLE
Make code compatible with Visual Studio

### DIFF
--- a/include/bit.h
+++ b/include/bit.h
@@ -7,9 +7,10 @@
 #include <chb.h>
 
 #include <memory.h>
+#include <stdint.h>
 
 struct bit {
-	const void* data;
+	const uint8_t* data;
 	size_t size;
 
 	const char* ncd_filename;

--- a/include/ov.h
+++ b/include/ov.h
@@ -22,13 +22,25 @@ extern "C" {
 
 struct ov_device;
 
-struct __attribute__((packed)) ov_packet {
+#ifdef _MSC_VER
+#pragma pack(push, 1)
+#endif
+struct
+#ifdef __GNUC__
+	__attribute__((packed))
+#elif !defined(_MSC_VER)
+	#error Please provide __attribute__((packed)) for your compiler
+#endif
+ov_packet {
 	uint8_t  magic;
 	uint16_t flags;
 	uint16_t size;
 	uint32_t timestamp : 24;
 	uint8_t  data[];
 };
+#ifdef _MSC_VER
+#pragma pack(pop)
+#endif
 
 typedef void (*ov_packet_decoder_callback)(struct ov_packet*, void*);
 

--- a/src/bit.c
+++ b/src/bit.c
@@ -6,8 +6,14 @@
 #include <string.h>
 
 #if __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
-#	define be_to_host_16(x) (__builtin_bswap16(x))
-#	define be_to_host_32(x) (__builtin_bswap32(x))
+#	ifdef _MSC_VER
+#		include <stdlib.h>
+#		define be_to_host_16(x) (_byteswap_ushort(x))
+#		define be_to_host_32(x) (_byteswap_ulong(x))
+#	else
+#		define be_to_host_16(x) (__builtin_bswap16(x))
+#		define be_to_host_32(x) (__builtin_bswap32(x))
+#	endif
 #elif __BYTE_ORDER__ == __ORDER_BIG_ENDIAN__
 #	define be_to_host_16(x) (x)
 #	define be_to_host_32(x) (x)


### PR DESCRIPTION
Use uint8_t* data in struct bit instead of void pointer as arithmetic
operations are not valid on void pointers (void pointer arithmetics is
non portable gcc extension).

Use #pragma pack(push, 1) and #pragma pack(pop) instead of
__attribute__((packed)) when building with Visual Studio.

Use _byteswap_ushort() and _byteswap_ulong() instead of gcc builtins.