### PR TITLE
Use OPENVIZSLA_EXPORT macro in ov.h

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -82,7 +82,7 @@ install:
 before_build:
   - mkdir build
   - cd build
-  - cmake -G"%GENERATOR%" -DCMAKE_TOOLCHAIN_FILE=c:/tools/vcpkg/scripts/buildsystems/vcpkg.cmake -DVCPKG_TARGET_TRIPLET=%VCPKG_TARGET_TRIPLET% -DCMAKE_BUILD_TYPE=%CONFIGURATION% ..
+  - cmake -G"%GENERATOR%" -DCMAKE_TOOLCHAIN_FILE=c:/tools/vcpkg/scripts/buildsystems/vcpkg.cmake -DVCPKG_TARGET_TRIPLET=%VCPKG_TARGET_TRIPLET% -DCMAKE_BUILD_TYPE=%CONFIGURATION% -DBUILD_SHARED_LIBS:BOOL=on ..
 build_script:
   - cmake --build . --config %CONFIGURATION%
 test_script:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -131,6 +131,8 @@ install(TARGETS openvizsla
 	DESTINATION ${CMAKE_INSTALL_FULL_LIBDIR})
 install(FILES "include/ov.h"
 	DESTINATION ${CMAKE_INSTALL_FULL_INCLUDEDIR}/openvizsla)
+install(FILES "${CMAKE_CURRENT_BINARY_DIR}/openvizsla_export.h"
+	DESTINATION ${CMAKE_INSTALL_FULL_INCLUDEDIR}/openvizsla)
 configure_file("openvizsla.pc.in" "openvizsla.pc" @ONLY)
 install(FILES "${CMAKE_CURRENT_BINARY_DIR}/openvizsla.pc"
 	DESTINATION "${CMAKE_INSTALL_FULL_LIBDIR}/pkgconfig")

--- a/include/ov.h
+++ b/include/ov.h
@@ -6,6 +6,8 @@
 #include <stddef.h>
 #include <stdint.h>
 
+#include <openvizsla_export.h>
+
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -50,20 +52,20 @@ enum ov_usb_speed {
 	OV_HIGH_SPEED = 0x48
 };
 
-struct ov_device* ov_new(const char* firmware_filename);
-int  ov_open(struct ov_device* ov);
-void ov_free(struct ov_device* ov);
+OPENVIZSLA_EXPORT struct ov_device* ov_new(const char* firmware_filename);
+OPENVIZSLA_EXPORT int  ov_open(struct ov_device* ov);
+OPENVIZSLA_EXPORT void ov_free(struct ov_device* ov);
 
-int ov_get_usb_speed(struct ov_device* ov, enum ov_usb_speed* speed);
-int ov_set_usb_speed(struct ov_device* ov, enum ov_usb_speed speed);
+OPENVIZSLA_EXPORT int ov_get_usb_speed(struct ov_device* ov, enum ov_usb_speed* speed);
+OPENVIZSLA_EXPORT int ov_set_usb_speed(struct ov_device* ov, enum ov_usb_speed speed);
 
-int ov_capture_start(struct ov_device* ov, struct ov_packet* packet, size_t packet_size, ov_packet_decoder_callback callback, void* user_data);
-int ov_capture_dispatch(struct ov_device* ov, int count);
-int ov_capture_stop(struct ov_device* ov);
+OPENVIZSLA_EXPORT int ov_capture_start(struct ov_device* ov, struct ov_packet* packet, size_t packet_size, ov_packet_decoder_callback callback, void* user_data);
+OPENVIZSLA_EXPORT int ov_capture_dispatch(struct ov_device* ov, int count);
+OPENVIZSLA_EXPORT int ov_capture_stop(struct ov_device* ov);
 
-int ov_load_firmware(struct ov_device* ov, const char* filename);
+OPENVIZSLA_EXPORT int ov_load_firmware(struct ov_device* ov, const char* filename);
 
-const char* ov_get_error_string(struct ov_device* ov);
+OPENVIZSLA_EXPORT const char* ov_get_error_string(struct ov_device* ov);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
This fixes compilation error while building libopenvizsla using vcpkg.

I cannot get the unit tests to build using vcpkg. I got the library to build with vcpkg when I simply removed the tests from CMakeLists.txt.