### PR TITLE
Stream synchronization fixes

### DIFF
--- a/src/decoder.c
+++ b/src/decoder.c
@@ -71,7 +71,7 @@ int packet_decoder_proc(struct packet_decoder* pd, uint8_t* buf, size_t size) {
 				}
 			} break;
 			case NEED_PACKET_DATA: {
-				const size_t required_length = pd->packet->size - pd->buf_actual_length;
+				const size_t required_length = ov_packet_captured_size(pd->packet) - pd->buf_actual_length;
 				const size_t copy = MIN(required_length, end - buf);
 
 				memcpy(pd->packet->data + pd->buf_actual_length, buf, copy);

--- a/tools/sample/main.c
+++ b/tools/sample/main.c
@@ -11,7 +11,7 @@
 
 static void packet_handler(struct ov_packet* packet, void* data) {
 	printf("[%02x] Received %d bytes at %" PRId64 ":", packet->flags, packet->size, packet->timestamp);
-	for (int i = 0; i < packet->size; ++i)
+	for (int i = 0; i < ov_packet_captured_size(packet); ++i)
 		printf(" %02x", packet->data[i]);
 	printf("\n");
 }


### PR DESCRIPTION
Read cha data in max packet size chunks

Commit https://github.com/matwey/libopenvizsla/commit/56c5d37bcdf9b2e82d2bb91557e9a6317849521d ("Refactor cha_loop") changed libusb bulk transfer size from endpoint max packet size to 4096. This change inadvertently leads to RX stream desynchronization when there is large traffic on captured link. The data stream gets desynchronized because FTDI FT2232H prepends Modem Status and Line Status on every DATA packet it sends to capture host and the 4096 bytes buffer, when OpenVizsla is connected to High-Speed capture host, can hold up to 8 DATA packets and therefore the completed transfer can contain up to 16 status bytes, but transfer callback only skips the first two status bytes.

Fix the issue by skipping the Modem Status and Line Status on every max packet size chunk within the received buffer.

Do not lose synchronization on truncated packets

In current bitstream introduced in commit https://github.com/matwey/libopenvizsla/commit/d0192dca8ab58751150d3c964df5b96254777995 ("Update to latest FPGA bitstream") only 1027 bytes are captured when HF0_TRUNC flag is set. HF0_TRUNC can happen either when there is babble packet on the bus or when the gateware incoming ULPI buffer gets full. When HF0_TRUNC is set, the packet size stored in header is guaranteed to be larger than 1027 but only 1027 bytes are actually captured. The next packet data are then incorrectly treated as remainder of the packet and therefore the stream gets out of sync.

Fix the issue by respecting gateware maximum captured packet size.